### PR TITLE
Fix mktemp error.

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -86,7 +86,7 @@ install_keyring() {
     fi
 
     # Unpacking
-    TMPDIR=$(mktemp -d /tmp/system-image/tmp.XXXXX)
+    TMPDIR=$(mktemp -dt -p /tmp/system-image/ tmp.XXXXXXXXXX)
     cd $TMPDIR
     cat $1 | unxz | tar xf -
     if [ ! -e keyring.json ] || [ ! -e keyring.gpg ]; then


### PR DESCRIPTION
 	Fix mktemp error.

mktemp -d /tmp/system-image/tmp.XXXXX
mktemp: Invalid argument