### PR TITLE
Remove tarball after each update command

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -452,7 +452,7 @@ do
                 continue
             fi
 
-            REMOVE_LIST="$REMOVE_LIST /cache/recovery/$2 /cache/recovery/$3"
+            REMOVE_LIST="$REMOVE_LIST /cache/recovery/$3"
 
             if ! verify_signature device-signing /cache/recovery/$3 && \
                ! verify_signature image-signing /cache/recovery/$3; then
@@ -492,6 +492,11 @@ do
                     rm partitions/${part}.img
                 fi
             done
+
+            # Remove tarball to free up space, since device tarballs
+            # extract partitions/blobs that might fill up cache,
+            # this way we ensure we got space for the partitions/blobs
+            rm -f recovery/$2
         ;;
 
         *)


### PR DESCRIPTION
Remove tarball to free up space, since device tarballs extract
partitions/blobs that might fill up cache, this way we ensure we got
space for the partitions/blobs

This will help https://github.com/ubports/ubuntu-touch/issues/673 to get more room. 

This should free about 100mb of space we can use extra.