### PR TITLE
Flash partitions without help of fstab

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -492,6 +492,16 @@ do
                     rm partitions/${part}.img
                 fi
             done
+            if [ -e partitions/basepath.txt ]; then
+            basepath=$(cat partitions/basepath.txt)
+            ls partitions/*.newimg | while read line; do
+                basename=$(basename -- "$line")
+                path=${basepath}/${basename%.*}
+                echo "Flashing ${line} at ${path}"
+                cat ${line} > ${path}
+                rm ${line}
+                done
+            fi
         ;;
 
         *)


### PR DESCRIPTION
This additional flash function aims at not having to wait for 2 OTA cycles for a new partition to be flashed. The old approach needed the modification in fstab to land in the first OTA cycle, then at the next one it would actually pick it up and flash the partition.

Since a partition does not need to be mounted for flashing there is no need for use of fstab at all, in fact it can be detrimental.

basepath.txt holds the device-specific path to the /dev node of the partition. In order to not interfere with the old system, new partitions being added with this method need to have the extension .newimg
