### PR TITLE
system-image-upgrader: Re-enable GPG verification

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -43,9 +43,6 @@ check_filesystem() {
 verify_signature() {
     # $1 => validation keyring name
     # $2 => path to validate
-  #  if [ -e /etc/system-image/skip-gpg-verification ]; then
-     return 0
-  #  fi
 
     if [ ! -e $2 ]; then
         echo "File doesn't exist: $2"

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -43,6 +43,10 @@ check_filesystem() {
 verify_signature() {
     # $1 => validation keyring name
     # $2 => path to validate
+    if [ -e /etc/system-image/skip-gpg-verification ]; then
+        echo "Skipping GPG verification"
+        return 0
+    fi
 
     if [ ! -e $2 ]; then
         echo "File doesn't exist: $2"


### PR DESCRIPTION
Early in the development process of the Halium 7.1 recovery
this seems to have been disabled for debugging purposes. Re-enable now!

Change-Id: I322bfae2e4cee30d2ffa7775a5bc1044dd957209