### PR TITLE
Cherry-pick system-image-upgrader from Halium-7.1

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -433,6 +433,8 @@ do
                 system)
                     mkdir -p "$SYSTEM_MOUNTPOINT"
                     if [ "$USE_SYSTEM_PARTITION" -eq 1 ];then
+                        umount $SYSTEM_PARTITION || true
+                        umount $SYSTEM_MOUNTPOINT || true
                         check_filesystem $SYSTEM_PARTITION
                         mount $SYSTEM_PARTITION "$SYSTEM_MOUNTPOINT"
                     else

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -88,7 +88,7 @@ install_keyring() {
     # Unpacking
     TMPDIR=$(mktemp -dt -p /tmp/system-image/ tmp.XXXXXXXXXX)
     cd $TMPDIR
-    cat $1 | unxz | tar xf -
+    xzcat $1 | tar --numeric-owner -xf -
     if [ ! -e keyring.json ] || [ ! -e keyring.gpg ]; then
         rm -Rf $TMPDIR
         echo "Invalid keyring: $1"
@@ -267,7 +267,15 @@ fi
 # Initialize recovery SWAP
 ## Without a swap some systems will fail to install the ubuntu rootfs (due its size)
 if [ ! -e /cache/recovery/SWAP.img ]; then
-    dd if=/dev/zero of=/cache/recovery/SWAP.img bs=4096 count=8192
+    # Determine size based on device maintainer preference, set in the kernel
+    # cmdline. This falls back to using 32MB for the total swap file size.
+    if grep -q siu.swapsize= /proc/cmdline; then
+        swap_size=$(cat /proc/cmdline | sed "s/ /\n/g" | grep siu.swapsize= | awk -F "=" '{ print $2 }')
+    else
+        swap_size=32
+    fi
+    echo "Swap size: $swap_size MB"
+    dd if=/dev/zero of=/cache/recovery/SWAP.img bs=1M count=$swap_size
     mkswap /cache/recovery/SWAP.img
 fi
 swapon /cache/recovery/SWAP.img
@@ -303,7 +311,9 @@ do
                 system)
                     FULL_IMAGE=1
                     if [ "$USE_SYSTEM_PARTITION" -eq 1 ];then
-                        make.ext4fs $SYSTEM_PARTITION
+                        echo "system partition: $SYSTEM_PARTITION"
+                        umount /system || true
+                        make_ext4fs $SYSTEM_PARTITION
                     else
                         #system.img is the deprecated name for ubuntu.img, handle that too
                         rm -f /data/system.img
@@ -321,6 +331,22 @@ do
                                     continue
                             fi
                         fi
+
+                        # Some devices use /data as /cache, so avoid removing
+                        # files that are essential to flashing and upgrading
+                        if [ "$entry" == "/data/recovery" ]; then
+                            continue
+                        fi
+                        if [ "$entry" == "/data/system-image-upgrader.log" ]; then
+                            continue
+                        fi
+                        if [ "$entry" == "/data/test.log" ]; then
+                            continue
+                        fi
+                        if [ "$entry" == "/data/ubuntu_updater.log" ]; then
+                            continue
+                        fi
+
                         rm -Rf $entry
                     done
                     # mtp is always enabled by default
@@ -466,7 +492,7 @@ do
 
             # Start by removing any file listed in "removed"
             if [ "$FULL_IMAGE" != "1" ]; then
-                cat recovery/$2 | unxz | tar xf - removed >/dev/null 2>&1 || true
+                xzcat recovery/$2 | tar --numeric-owner -xf - removed >/dev/null 2>&1 || true
                 if [ -e removed ]; then
                     while read file; do
                         rm -Rf $file
@@ -476,7 +502,7 @@ do
             fi
 
             # Unpack everything else on top of the system partition
-            cat recovery/$2 | unxz | tar xf -
+            xzcat recovery/$2 | tar --numeric-owner -xf -
             rm -f removed
 
             # Process partition images

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -435,6 +435,7 @@ do
                     if [ "$USE_SYSTEM_PARTITION" -eq 1 ];then
                         umount $SYSTEM_PARTITION || true
                         umount $SYSTEM_MOUNTPOINT || true
+                        umount /system || true
                         check_filesystem $SYSTEM_PARTITION
                         mount $SYSTEM_PARTITION "$SYSTEM_MOUNTPOINT"
                     else

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -291,7 +291,7 @@ fi
 # However, do not use the block device name in the kernel command line, as that is not consistently
 # named in booting normal and recovery modes. Expect fstab to have a system mountpoint or use a fallback.
 if [ "$USE_SYSTEM_PARTITION" -eq 1 ];then
-    SYSTEM_PARTITION=$(grep "/system" /etc/recovery.fstab |cut -f 1 -d\ )
+    SYSTEM_PARTITION=$(grep "^[^#]" /etc/recovery.fstab | grep "/system" | cut -f 1 -d\ )
     #Fall back to emmc@android if there's no system in fstab
     if [ "$SYSTEM_PARTITION" == "" ]; then
         SYSTEM_PARTITION = "emmc@android"

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -334,16 +334,7 @@ do
 
                         # Some devices use /data as /cache, so avoid removing
                         # files that are essential to flashing and upgrading
-                        if [ "$entry" == "/data/recovery" ]; then
-                            continue
-                        fi
-                        if [ "$entry" == "/data/system-image-upgrader.log" ]; then
-                            continue
-                        fi
-                        if [ "$entry" == "/data/test.log" ]; then
-                            continue
-                        fi
-                        if [ "$entry" == "/data/ubuntu_updater.log" ]; then
+                        if [ "$entry" == "/data/cache" ]; then
                             continue
                         fi
 


### PR DESCRIPTION
Recovery on Halium-5.1 has fallen behind 7.1 for some time now. Though there are no important ports in progress, housekeeping should be made to keep 5.1 alive (as long as we do not decide to deprecate it).

As the recovery sources in 7.1 are no longer compatible with 5.1, and, moreover, the new recovery was planted on top of CM-14.1 recovery by cherry-picking itself, I decided to also cherry-pick what's needed:
* A bugfix that prevents creating an ext4 file system (typo) in 40299adb747c29c2bf83b0dffd4126fa3e820889
* All other fixes that Alfred and Marius have done to make recovery more resilient