### PR TITLE
system-image-upgrader: Fix reset to factory defaults

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -324,7 +324,7 @@ do
                 data)
                     for entry in /data/* /data/.writable_image /data/.factory_wipe; do
                         if [ "$USE_SYSTEM_PARTITION" -eq 0 ];then
-                            if [ "$entry" == "/data/rootfs.img" ]; then
+                            if [ "$entry" == "/data/rootfs.img" ] || [ "$entry" == "/data/system.img" ]; then
                                     continue
                             fi
                         fi


### PR DESCRIPTION
Similar to halium-7.1 branch, but with different syntax. Seems that ash/bash/whatevershall syntax need to be tried for every Android version.
