### PR TITLE
Use legacy bootmode for Ubuntu Touch

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -266,7 +266,7 @@ if [ -e /etc/system-image/archive-master.tar.xz ]; then
 fi
 
 # Initialize recovery SWAP
-## Without a swap some systems will fail to install the ubuntu (due its size)
+## Without a swap some systems will fail to install the ubuntu rootfs (due its size)
 if [ ! -e /cache/recovery/SWAP.img ]; then
     # Determine size based on device maintainer preference, set in the kernel
     # cmdline. This falls back to using 32MB for the total swap file size.

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -311,17 +311,17 @@ do
             case "$2" in
                 system)
                     FULL_IMAGE=1
+                    # Cleanup files left from halium-install
+                    rm -f /data/system.img
+                    rm -f /data/rootfs.img
+                    # Delete ubuntu.img if present. Either its a leftover, or we recreate it
+                    rm -f /data/ubuntu.img
                     if [ "$USE_SYSTEM_PARTITION" -eq 1 ];then
                         echo "system partition: $SYSTEM_PARTITION"
                         umount /system || true
                         make_ext4fs $SYSTEM_PARTITION
                     else
-                        # Cleanup a previous install from halium-install, too
-                        rm -f /data/system.img
-                        rm -f /data/rootfs.img
-                        # We need to use legacy image name here, halium-boot does not
-                        # allow rootfs.img to contain the system image and expects system.img to be present
-                        rm -f /data/ubuntu.img
+                        # We need to use legacy image name here, halium-boot needs this to decide file layout
                         dd if=/dev/zero of=/data/ubuntu.img seek=500K bs=4096 count=0
                         mkfs.ext2 -F /data/ubuntu.img
                     fi

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -313,6 +313,7 @@ do
                     FULL_IMAGE=1
                     # Cleanup files left from halium-install
                     rm -f /data/system.img
+                    rm -f /data/android-rootfs.img
                     rm -f /data/rootfs.img
                     # Delete ubuntu.img if present. Either its a leftover, or we recreate it
                     rm -f /data/ubuntu.img
@@ -330,7 +331,7 @@ do
                 data)
                     for entry in /data/* /data/.writable_image /data/.factory_wipe; do
                         if [ "$USE_SYSTEM_PARTITION" -eq 0 ];then
-                            if [[ ( "$entry" == "/data/ubuntu.img" ) || ( "$entry" == "/data/rootfs.img" ) || ( "$entry" == "/data/system.img" ) ]]; then
+                            if [[ ( "$entry" == "/data/ubuntu.img" ) || ( "$entry" == "/data/rootfs.img" ) || ( "$entry" == "/data/system.img" ) || ( "$entry" == "/data/android-rootfs.img" ) ]]; then
                                     continue
                             fi
                         fi

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -307,7 +307,7 @@ do
     set -- $line
     case "$1" in
         format)
-            echo "Formating: $2"
+            echo "Formatting: $2"
             case "$2" in
                 system)
                     FULL_IMAGE=1

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -266,7 +266,7 @@ if [ -e /etc/system-image/archive-master.tar.xz ]; then
 fi
 
 # Initialize recovery SWAP
-## Without a swap some systems will fail to install the ubuntu rootfs (due its size)
+## Without a swap some systems will fail to install the ubuntu (due its size)
 if [ ! -e /cache/recovery/SWAP.img ]; then
     # Determine size based on device maintainer preference, set in the kernel
     # cmdline. This falls back to using 32MB for the total swap file size.
@@ -316,16 +316,21 @@ do
                         umount /system || true
                         make_ext4fs $SYSTEM_PARTITION
                     else
+                        # Cleanup a previous install from halium-install, too
+                        rm -f /data/system.img
                         rm -f /data/rootfs.img
-                        dd if=/dev/zero of=/data/rootfs.img seek=500K bs=4096 count=0
-                        mkfs.ext2 -F /data/rootfs.img
+                        # We need to use legacy image name here, halium-boot does not
+                        # allow rootfs.img to contain the system image and expects system.img to be present
+                        rm -f /data/ubuntu.img
+                        dd if=/dev/zero of=/data/ubuntu.img seek=500K bs=4096 count=0
+                        mkfs.ext2 -F /data/ubuntu.img
                     fi
                 ;;
 
                 data)
                     for entry in /data/* /data/.writable_image /data/.factory_wipe; do
                         if [ "$USE_SYSTEM_PARTITION" -eq 0 ];then
-                            if [[ ( "$entry" == "/data/rootfs.img" ) || ( "$entry" == "/data/system.img" ) ]]; then
+                            if [[ ( "$entry" == "/data/ubuntu.img" ) || ( "$entry" == "/data/rootfs.img" ) || ( "$entry" == "/data/system.img" ) ]]; then
                                     continue
                             fi
                         fi
@@ -437,8 +442,8 @@ do
                         check_filesystem $SYSTEM_PARTITION
                         mount $SYSTEM_PARTITION "$SYSTEM_MOUNTPOINT"
                     else
-                        check_filesystem /data/rootfs.img
-                        mount -o loop /data/rootfs.img "$SYSTEM_MOUNTPOINT/"
+                        check_filesystem /data/ubuntu.img
+                        mount -o loop /data/ubuntu.img "$SYSTEM_MOUNTPOINT/"
                     fi
                 ;;
 
@@ -557,8 +562,8 @@ fi
 
 # Ensure we have sane permissions
 if [ "$USE_SYSTEM_PARTITION" -eq 0 ];then
-    chmod 600 /data/rootfs.img
-    chown 0:0 /data/rootfs.img
+    chmod 600 /data/ubuntu.img
+    chown 0:0 /data/ubuntu.img
 fi
 chmod 600 /data/SWAP.img
 chown 0:0 /data/SWAP.img


### PR DESCRIPTION
This came up during work on the upgrade ports for FP2, OPO and N5:
- halium-boot can boot a variety of file layouts
- Recovery install correctly when system image is in system partition
- However, as soon as system image should be in a file in userdata, recovery for 7.1 and 9.0 does only create rootfs.img and puts system.img inside
- This is not the expected file layout for halium-boot, it detects halium mode and tries to mount system.img
- Better: Bring back the old name "ubuntu.img", this will be recognized by halium-boot