### PR TITLE
Use legacy bootmode for Ubuntu Touch

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -319,7 +319,7 @@ do
                 data)
                     for entry in /data/* /data/.writable_image /data/.factory_wipe; do
                         if [ "$USE_SYSTEM_PARTITION" -eq 0 ];then
-                            if [[ ( "$entry" == "/data/ubuntu.img" ) || ( "$entry" == "/data/rootfs.img" ) || ( "$entry" == "/data/system.img" ) ]]; then
+                            if [ "$entry" == "/data/system.img" -o "$entry" == "/data/ubuntu.img" -o "$entry" == "/data/rootfs.img" ]; then
                                     continue
                             fi
                         fi

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -304,6 +304,7 @@ do
                     FULL_IMAGE=1
                     # Cleanup files left from halium-install
                     rm -f /data/system.img
+                    rm -f /data/android-rootfs.img
                     rm -f /data/rootfs.img
                     # Delete ubuntu.img if present. Either its a leftover, or we recreate it
                     rm -f /data/ubuntu.img
@@ -319,7 +320,7 @@ do
                 data)
                     for entry in /data/* /data/.writable_image /data/.factory_wipe; do
                         if [ "$USE_SYSTEM_PARTITION" -eq 0 ];then
-                            if [ "$entry" == "/data/system.img" -o "$entry" == "/data/ubuntu.img" -o "$entry" == "/data/rootfs.img" ]; then
+                            if [ "$entry" == "/data/system.img" -o "$entry" == "/data/ubuntu.img" -o "$entry" == "/data/rootfs.img" -o "$entry" == "/data/android-rootfs.img" ]; then
                                     continue
                             fi
                         fi

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -298,26 +298,28 @@ do
     set -- $line
     case "$1" in
         format)
-            echo "Formating: $2"
+            echo "Formatting: $2"
             case "$2" in
                 system)
                     FULL_IMAGE=1
+                    # Cleanup files left from halium-install
+                    rm -f /data/system.img
+                    rm -f /data/rootfs.img
+                    # Delete ubuntu.img if present. Either its a leftover, or we recreate it
+                    rm -f /data/ubuntu.img
                     if [ "$USE_SYSTEM_PARTITION" -eq 1 ];then
                         make.ext4fs $SYSTEM_PARTITION
                     else
-                        #system.img is the deprecated name for ubuntu.img, handle that too
-                        rm -f /data/system.img
-                        rm -f /data/ubuntu.img
+                        # We need to use legacy image name here, halium-boot needs this to decide file layout
                         dd if=/dev/zero of=/data/ubuntu.img seek=500K bs=4096 count=0
                         mkfs.ext2 -F /data/ubuntu.img
-                        ln /data/ubuntu.img /data/system.img
                     fi
                 ;;
 
                 data)
                     for entry in /data/* /data/.writable_image /data/.factory_wipe; do
                         if [ "$USE_SYSTEM_PARTITION" -eq 0 ];then
-                            if [ "$entry" == "/data/system.img" -o "$entry" == "/data/ubuntu.img" ]; then
+                            if [[ ( "$entry" == "/data/ubuntu.img" ) || ( "$entry" == "/data/rootfs.img" ) || ( "$entry" == "/data/system.img" ) ]]; then
                                     continue
                             fi
                         fi
@@ -419,9 +421,6 @@ do
                         check_filesystem $SYSTEM_PARTITION
                         mount $SYSTEM_PARTITION "$SYSTEM_MOUNTPOINT"
                     else
-                        if [ ! -e /data/ubuntu.img ]; then
-                            ln /data/system.img /data/ubuntu.img
-                        fi
                         check_filesystem /data/ubuntu.img
                         mount -o loop /data/ubuntu.img "$SYSTEM_MOUNTPOINT/"
                     fi


### PR DESCRIPTION
See also #19 ... Basically this becomes necessary as devices flashed with old recovery should be on par with the Halium recovery here. Having different codepaths is messy when looking for bugs. Also, the hardlink to system.img is really not needed any longer.
