### PR TITLE
Check for legacy channel flag and hardlink system.img again

### DIFF
--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -504,7 +504,7 @@ do
             # Check for legacy channel flag and hardlink system.img again
             if [ -e legacy_channel ]; then
                 ln /data/ubuntu.img /data/system.img || true
-                rm legacy_channel
+                rm -f legacy_channel
             fi
             
             # Move things to data

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -504,6 +504,7 @@ do
             # Check for legacy channel flag and hardlink system.img again
             if [ -e legacy_channel ]; then
                 ln /data/ubuntu.img /data/system.img || true
+                rm legacy_channel
             fi
             
             # Move things to data

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -501,6 +501,11 @@ do
             xzcat recovery/$2 | tar --numeric-owner -xf -
             rm -f removed
 
+            # Check for legacy channel flag and hardlink system.img again
+            if [ -e legacy_channel ]; then
+                ln /data/ubuntu.img /data/system.img || true
+            fi
+            
             # Move things to data
             mv data/* /data/ || true
             rm -Rf data || true


### PR DESCRIPTION
This became necessary as it turns out that the legacy initramfs does indeed use system.img as filename for the rootfs, in contrast to what recovery made us believe. As its easier to fix it in the recovery script than creating a new initrd for the old devices, lets do it like this.