### PR TITLE
recovery: use correct path for UT adb_keys

### DIFF
--- a/recovery.cpp
+++ b/recovery.cpp
@@ -1660,7 +1660,7 @@ load_locale_from_cache() {
     }
 }
 
-static const char *key_src = "/data/misc/adb/adb_keys";
+static const char *key_src = "/data/android-data/misc/adb/adb_keys";
 static const char *key_dest = "/adb_keys";
 
 


### PR DESCRIPTION
Change-Id: Ie5b710397561817da0d8ee5ebc46e7649ccaef6e