### PR TITLE
Use bsdtar

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -168,7 +168,8 @@ LOCAL_ADDITIONAL_DEPENDENCIES += \
     bu_recovery \
     busybox_links \
     static_busybox \
-    static_gpg
+    static_gpg \
+    bsdtar-recovery
 
 endif
 

--- a/system-image-upgrader
+++ b/system-image-upgrader
@@ -89,7 +89,7 @@ install_keyring() {
     # Unpacking
     TMPDIR=$(mktemp -dt -p /tmp/system-image/ tmp.XXXXXXXXXX)
     cd $TMPDIR
-    xzcat $1 | tar --numeric-owner -xf -
+    xzcat $1 | bsdtar --numeric-owner -Ppxf -
     if [ ! -e keyring.json ] || [ ! -e keyring.gpg ]; then
         rm -Rf $TMPDIR
         echo "Invalid keyring: $1"
@@ -488,7 +488,7 @@ do
 
             # Start by removing any file listed in "removed"
             if [ "$FULL_IMAGE" != "1" ]; then
-                xzcat recovery/$2 | tar --numeric-owner -xf - removed >/dev/null 2>&1 || true
+                xzcat recovery/$2 | bsdtar --numeric-owner -pxf - removed >/dev/null 2>&1 || true
                 if [ -e removed ]; then
                     while read file; do
                         rm -Rf $file
@@ -498,7 +498,7 @@ do
             fi
 
             # Unpack everything else on top of the system partition
-            xzcat recovery/$2 | tar --numeric-owner -xf -
+            xzcat recovery/$2 | bsdtar --numeric-owner -Ppxf -
             rm -f removed
 
             # Check for legacy channel flag and hardlink system.img again


### PR DESCRIPTION
This PR changes `system-image-upgrader` to use `bsdtar` instead of toybox's `tar` implementation, to support extended file attributes when unpacking the rootfs.